### PR TITLE
Refactoring of tests.

### DIFF
--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -679,7 +679,7 @@ function describeTest(test) {
   return ctor + fnCall + expectedResult + error;
 }
 
-describe("Complex", function () {
+describe("Complex functions", function () {
 
   for (var i = 0; i < functionTests.length; i++) {
 
@@ -698,6 +698,9 @@ describe("Complex", function () {
       });
     })(functionTests[i]);
   }
+});
+
+describe("Complex constructor", function() {
 
   for (var i = 0; i < constructorTests.length; i++) {
 

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -687,7 +687,7 @@ describe("Complex functions", function () {
 
       it(describeTest(test), function () {
         try {
-          assert.equal(test.expect, new Complex(test.set)[test.fn](test.param).toString());
+          assert.equal(new Complex(test.set)[test.fn](test.param).toString(), test.expect);
         } catch (e) {
           if (test.error) {
             assert.equal(e.toString(), test.error.toString());
@@ -707,7 +707,7 @@ describe("Complex constructor", function() {
     (function (test) {
       it(describeTest(test), function () {
         try {
-          assert.equal(test.expect, new Complex(test.set).toString());
+          assert.equal(new Complex(test.set).toString(), test.expect);
         } catch (e) {
           if (test.error) {
             assert.equal(e.toString(), test.error.toString());

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -652,6 +652,30 @@ var tests = [{
   }
 ];
 
+function stringify(value) {
+  return typeof value === "number"
+    ? value.toString()
+    : JSON.stringify(value);
+}
+
+function describeTest(test) {
+  var ctor = "new Complex(" + (test.set !== undefined ? stringify(test.set) : "") + ")";
+
+  var fnCall = test.fn == null
+    ? ""
+    : "." + test.fn + "(" + (test.param !== undefined ? stringify(test.param) : "") + ")";
+
+  var expectedResult = test.expect == null
+    ? ""
+    : " === " + stringify(test.expect);
+
+  var error = test.error == null
+    ? ""
+    : " should throw " + test.error;
+
+  return ctor + fnCall + expectedResult + error;
+}
+
 describe("Complex", function () {
 
   for (var i = 0; i < tests.length; i++) {
@@ -660,7 +684,7 @@ describe("Complex", function () {
 
       if (tests[i].fn) {
 
-        it((tests[i].fn || "") + " " + tests[i].set + ", " + (tests[i].param || ""), function () {
+        it(describeTest(tests[i]), function () {
           try {
             assert.equal(tests[i].expect, new Complex(tests[i].set)[tests[i].fn](tests[i].param).toString());
           } catch (e) {
@@ -669,8 +693,7 @@ describe("Complex", function () {
         });
 
       } else {
-
-        it((tests[i].fn || "") + "" + tests[i].set, function () {
+        it(describeTest(tests[i]), function () {
           try {
             assert.equal(tests[i].expect, new Complex(tests[i].set).toString());
           } catch (e) {

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -3,66 +3,6 @@ var assert = require("assert");
 var Complex = require("../complex.js");
 
 var tests = [{
-    set: null,
-    expect: "0"
-  }, {
-    set: undefined,
-    expect: "0"
-  }, {
-    set: "foo",
-    error: "SyntaxError: Invalid Param"
-  }, {
-    set: {},
-    error: "SyntaxError: Invalid Param"
-  }, {
-    set: " + i",
-    expect: "i"
-  }, {
-    set: "3+4i",
-    expect: "3 + 4i"
-  }, {
-    set: "i",
-    expect: "i"
-  }, {
-    set: "3",
-    expect: "3"
-  }, {
-    set: [9, 8],
-    expect: "9 + 8i"
-  }, {
-    set: "2.3",
-    expect: "2.3"
-  }, {
-    set: "0",
-    expect: "0"
-  }, {
-    set: "-0",
-    expect: "0"
-  }, {
-    set: {re: -0, im: 0},
-    expect: "0"
-  }, {
-    set: {re: 0, im: -0},
-    expect: "0"
-  }, {
-    set: Infinity,
-    expect: "Infinity"
-  }, {
-    set: -Infinity,
-    expect: "Infinity"
-  }, {
-    set: {re: Infinity, im: 0},
-    expect: "Infinity"
-  }, {
-    set: {re: -Infinity, im: 0},
-    expect: "Infinity"
-  }, {
-    set: {re: 0, im: Infinity},
-    expect: "Infinity"
-  }, {
-    set: {re: 0, im: -Infinity},
-    expect: "Infinity"
-  }, {
     set: Complex.I,
     fn: "mul",
     param: Complex(Math.PI).exp(),
@@ -72,9 +12,6 @@ var tests = [{
     fn: "mul",
     param: 3,
     expect: "3 + 12i"
-  }, {
-    set: 0,
-    expect: "0"
   }, {
     set: "4 + 3i",
     fn: "add",
@@ -606,15 +543,6 @@ var tests = [{
     fn: "cot",
     expect: "1.6636768291213935e-7 - 1.0000001515864902i"
   }, {
-    set: " + 7  - i  +  3i   -  +  +  +  + 43  +  2i  -  i4  +  -  33  +  65 - 1	",
-    expect: "-5"
-  }, {
-    set: " + 7  - i  +  3i   -  +  +  +  + 43  +  2i  -  i4  +  -  33  +  65 - 1	 + ",
-    error: "SyntaxError: Invalid Param"
-  }, {
-    set: "-3x + 4",
-    error: "SyntaxError: Invalid Param"
-  }, {
     set: Complex(1, 1).sub(0, 1), // Distance
     fn: "abs",
     expect: "1"
@@ -628,6 +556,78 @@ var tests = [{
     fn: "add",
     param: "i",
     expect: "6.123233995736766e-17 + 2i"
+  }, {
+    set: null,
+    expect: "0"
+  }, {
+    set: undefined,
+    expect: "0"
+  }, {
+    set: "foo",
+    error: "SyntaxError: Invalid Param"
+  }, {
+    set: {},
+    error: "SyntaxError: Invalid Param"
+  }, {
+    set: " + i",
+    expect: "i"
+  }, {
+    set: "3+4i",
+    expect: "3 + 4i"
+  }, {
+    set: "i",
+    expect: "i"
+  }, {
+    set: "3",
+    expect: "3"
+  }, {
+    set: [9, 8],
+    expect: "9 + 8i"
+  }, {
+    set: "2.3",
+    expect: "2.3"
+  }, {
+    set: "2.3",
+    expect: "2.3"
+  }, {
+    set: "0",
+    expect: "0"
+  }, {
+    set: "-0",
+    expect: "0"
+  }, {
+    set: {re: -0, im: 0},
+    expect: "0"
+  }, {
+    set: {re: 0, im: -0},
+    expect: "0"
+  }, {
+    set: Infinity,
+    expect: "Infinity"
+  }, {
+    set: -Infinity,
+    expect: "Infinity"
+  }, {
+    set: {re: Infinity, im: 0},
+    expect: "Infinity"
+  }, {
+    set: {re: -Infinity, im: 0},
+    expect: "Infinity"
+  }, {
+    set: {re: 0, im: Infinity},
+    expect: "Infinity"
+  }, {
+    set: {re: 0, im: -Infinity},
+    expect: "Infinity"
+  }, {
+    set: " + 7  - i  +  3i   -  +  +  +  + 43  +  2i  -  i4  +  -  33  +  65 - 1	",
+    expect: "-5"
+  }, {
+    set: " + 7  - i  +  3i   -  +  +  +  + 43  +  2i  -  i4  +  -  33  +  65 - 1	 + ",
+    error: "SyntaxError: Invalid Param"
+  }, {
+    set: "-3x + 4",
+    error: "SyntaxError: Invalid Param"
   }, {
     set: "- + 7",
     expect: "-7"

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 
 var Complex = require("../complex.js");
 
-var tests = [{
+var functionTests = [{
     set: Complex.I,
     fn: "mul",
     param: Complex(Math.PI).exp(),
@@ -556,7 +556,10 @@ var tests = [{
     fn: "add",
     param: "i",
     expect: "6.123233995736766e-17 + 2i"
-  }, {
+  }
+];
+
+var constructorTests = [{
     set: null,
     expect: "0"
   }, {
@@ -678,39 +681,39 @@ function describeTest(test) {
 
 describe("Complex", function () {
 
-  for (var i = 0; i < tests.length; i++) {
+  for (var i = 0; i < functionTests.length; i++) {
 
-    (function (i) {
+    (function (test) {
 
-      if (tests[i].fn) {
-
-        it(describeTest(tests[i]), function () {
-          try {
-            assert.equal(tests[i].expect, new Complex(tests[i].set)[tests[i].fn](tests[i].param).toString());
-          } catch (e) {
-            if (tests[i].error) {
-              assert.equal(e.toString(), tests[i].error.toString());
-            } else {
-              throw e;
-            }
+      it(describeTest(test), function () {
+        try {
+          assert.equal(test.expect, new Complex(test.set)[test.fn](test.param).toString());
+        } catch (e) {
+          if (test.error) {
+            assert.equal(e.toString(), test.error.toString());
+          } else {
+            throw e;
           }
-        });
+        }
+      });
+    })(functionTests[i]);
+  }
 
-      } else {
-        it(describeTest(tests[i]), function () {
-          try {
-            assert.equal(tests[i].expect, new Complex(tests[i].set).toString());
-          } catch (e) {
-            if (tests[i].error) {
-              assert.equal(e.toString(), tests[i].error.toString());
-            } else {
-              throw e;
-            }
+  for (var i = 0; i < constructorTests.length; i++) {
+
+    (function (test) {
+      it(describeTest(test), function () {
+        try {
+          assert.equal(test.expect, new Complex(test.set).toString());
+        } catch (e) {
+          if (test.error) {
+            assert.equal(e.toString(), test.error.toString());
+          } else {
+            throw e;
           }
-        });
-      }
-
-    })(i);
+        }
+      });
+    })(constructorTests[i]);
   }
 });
 

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -10,10 +10,10 @@ var tests = [{
     expect: "0"
   }, {
     set: "foo",
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: {},
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: " + i",
     expect: "i"
@@ -610,10 +610,10 @@ var tests = [{
     expect: "-5"
   }, {
     set: " + 7  - i  +  3i   -  +  +  +  + 43  +  2i  -  i4  +  -  33  +  65 - 1	 + ",
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: "-3x + 4",
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: Complex(1, 1).sub(0, 1), // Distance
     fn: "abs",
@@ -633,16 +633,16 @@ var tests = [{
     expect: "-7"
   }, {
     set: "4 5i",
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: "-",
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: "2.2e-1-3.2e-1i",
     expect: "0.22 - 0.32i"
   }, {
     set: "2.2.",
-    expect: "SyntaxError: Invalid Param"
+    error: "SyntaxError: Invalid Param"
   }, {
     set: {r: 0, phi: 4},
     expect: "0"
@@ -688,7 +688,11 @@ describe("Complex", function () {
           try {
             assert.equal(tests[i].expect, new Complex(tests[i].set)[tests[i].fn](tests[i].param).toString());
           } catch (e) {
-            assert.equal(e.toString(), tests[i].expect.toString());
+            if (tests[i].error) {
+              assert.equal(e.toString(), tests[i].error.toString());
+            } else {
+              throw e;
+            }
           }
         });
 
@@ -697,7 +701,11 @@ describe("Complex", function () {
           try {
             assert.equal(tests[i].expect, new Complex(tests[i].set).toString());
           } catch (e) {
-            assert.equal(e.toString(), tests[i].expect.toString());
+            if (tests[i].error) {
+              assert.equal(e.toString(), tests[i].error.toString());
+            } else {
+              throw e;
+            }
           }
         });
       }

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -686,14 +686,14 @@ describe("Complex functions", function () {
     (function (test) {
 
       it(describeTest(test), function () {
-        try {
-          assert.equal(new Complex(test.set)[test.fn](test.param).toString(), test.expect);
-        } catch (e) {
-          if (test.error) {
+        if (test.error) {
+          try {
+            new Complex(test.set)[test.fn](test.param);
+          } catch (e) {
             assert.equal(e.toString(), test.error.toString());
-          } else {
-            throw e;
           }
+        } else {
+          assert.equal(new Complex(test.set)[test.fn](test.param).toString(), test.expect);
         }
       });
     })(functionTests[i]);
@@ -706,14 +706,14 @@ describe("Complex constructor", function() {
 
     (function (test) {
       it(describeTest(test), function () {
-        try {
-          assert.equal(new Complex(test.set).toString(), test.expect);
-        } catch (e) {
-          if (test.error) {
+        if (test.error) {
+          try {
+            new Complex(test.set);
+          } catch (e) {
             assert.equal(e.toString(), test.error.toString());
-          } else {
-            throw e;
           }
+        } else {
+          assert.equal(new Complex(test.set).toString(), test.expect);
         }
       });
     })(constructorTests[i]);


### PR DESCRIPTION
Hi, I had a look at writing some new tests for the infinite branch.

This pr refactors tests with out really changing any of the test content to make the changes I am writing fit in better.

Commits 	f9ec596 to 6733dbd improves the description of tests logged by mocha, for example using `JSON.stringify` to remove unhelpful `[object Object]`s from the output.

Also, currently if I accidentally break a function and then run `npm test` then I get a very unhelpful message along the lines of `AssertionError [ERR_ASSERTION]: 'ReferenceError: sfdsdf is not defined' == '0.003 + 1100i'`.

eee8bde changes how errors are checked for. errors throw are compared to `test.error` and return values are compared to `test.expect` which improves this behaviour.

09c3645 and bebc835 separates constructor tests (those with out `fn`) from function tests which simplifies the code and makes it easier to read.


