### PR TITLE
Parse() correctly handles polar complex with infinite magnitude.

### DIFF
--- a/complex.js
+++ b/complex.js
@@ -145,9 +145,15 @@
             z['re'] = a['re'];
             z['im'] = a['im'];
           } else if ('abs' in a && 'arg' in a) {
+            if (!Number.isFinite(a['abs']) && Number.isFinite(a['arg'])) {
+              return Complex.INFINITY;
+            }
             z['re'] = a['abs'] * Math.cos(a['arg']);
             z['im'] = a['abs'] * Math.sin(a['arg']);
           } else if ('r' in a && 'phi' in a) {
+            if (!Number.isFinite(a['r']) && Number.isFinite(a['phi'])) {
+              return Complex.INFINITY;
+            }
             z['re'] = a['r'] * Math.cos(a['phi']);
             z['im'] = a['r'] * Math.sin(a['phi']);
           } else if (a.length === 2) { // Quick array check

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -652,13 +652,41 @@ var constructorTests = [{
   }, {
     set: {r: 1, phi: 1},
     expect: "0.5403023058681398 + 0.8414709848078965i"
+  }, {
+    set: {r: Infinity, phi: 0},
+    expect: "Infinity"
+  }, {
+    set: {r: Infinity, phi: 2},
+    expect: "Infinity"
+  }, {
+    set: {r: Infinity, phi: Infinity},
+    expect: "NaN"
+  }, {
+    set: {r: Infinity, phi: NaN},
+    expect: "NaN"
   }
 ];
 
+for (let i = 0, len = constructorTests.length; i < len; ++i) {
+  if (constructorTests[i].set != null && constructorTests[i].set.hasOwnProperty('r')) {
+    constructorTests.push({
+      set: {
+        abs: constructorTests[i].set.r,
+        arg: constructorTests[i].set.phi,
+      },
+      expect: constructorTests[i].expect
+    })
+  }
+}
+
+
 function stringify(value) {
-  return typeof value === "number"
-    ? value.toString()
-    : JSON.stringify(value);
+  return JSON.stringify(value, function replacer(key, val) {
+    if (typeof val === "number") {
+      return val.toString();
+    }
+    return val;
+  })
 }
 
 function describeTest(test) {


### PR DESCRIPTION
Improves the parse function so that now `parse{r: Infinity, phi: x})` where `x` is any finite Number will
return ComplexInfinity rather than ComplexNaN.

If `x` is infinite or NaN then parse will return ComplexNaN.

Also adds tests for these cases and duplicates any tests using `{r, phi}` to also run using `{abs, arg}`