### PR TITLE
docs: Fix simple typo, inprecision -> imprecision

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ A complex euler number instance
 
 Complex.EPSILON
 ---
-A small epsilon value used for `equals()` comparison in order to circumvent double inprecision.
+A small epsilon value used for `equals()` comparison in order to circumvent double imprecision.
 
 
 Installation


### PR DESCRIPTION
There is a small typo in README.md.

Should read `imprecision` rather than `inprecision`.

